### PR TITLE
Fix invalid match on setting keys in EbnfGrammarGenerator

### DIFF
--- a/libraries/Pliant/Ebnf/EbnfGrammarGenerator.cs
+++ b/libraries/Pliant/Ebnf/EbnfGrammarGenerator.cs
@@ -55,8 +55,8 @@ namespace Pliant.Ebnf
 
                 case EbnfNodeType.EbnfBlockSetting:
                     var blockSetting = block as EbnfBlockSetting;
-
-                    switch (blockSetting.Setting.SettingIdentifier.Value)
+                    var settingKey = blockSetting.Setting.SettingIdentifier.Value?.TrimStart(':');
+                    switch (settingKey)
                     {
                         case StartProductionSettingModel.SettingKey:
                             grammarModel.StartSetting = StartSetting(blockSetting);


### PR DESCRIPTION
the setting identifier seems to start with a ":", I'm assuming that this shouldn't be part of the identifier at all... but either way, this is an easy fix for it without making things too complicated